### PR TITLE
Added translation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 *.pyo
 *.so
+*.mo
 *~
 .#*
 .DS_Store
@@ -25,3 +26,5 @@ docs/_build
 /.vscode
 /_build
 /.pytest_cache
+/.idea/
+/.python-version

--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,51 @@
+[main]
+host = https://www.transifex.com
+
+[edgedb-docs.datamodel-pot]
+file_filter = doc/locales/<lang>/LC_MESSAGES/datamodel.po
+minimum_perc = 0
+source_file = _build/locale/datamodel.pot
+source_lang = en
+type = PO
+
+[edgedb-docs.edgeql-pot]
+file_filter = doc/locales/<lang>/LC_MESSAGES/edgeql.po
+minimum_perc = 0
+source_file = _build/locale/edgeql.pot
+source_lang = en
+type = PO
+
+[edgedb-docs.graphql-pot]
+file_filter = doc/locales/<lang>/LC_MESSAGES/graphql.po
+minimum_perc = 0
+source_file = _build/locale/graphql.pot
+source_lang = en
+type = PO
+
+[edgedb-docs.index-pot]
+file_filter = doc/locales/<lang>/LC_MESSAGES/index.po
+minimum_perc = 0
+source_file = _build/locale/index.pot
+source_lang = en
+type = PO
+
+[edgedb-docs.intro-pot]
+file_filter = doc/locales/<lang>/LC_MESSAGES/intro.po
+minimum_perc = 0
+source_file = _build/locale/intro.pot
+source_lang = en
+type = PO
+
+[edgedb-docs.quickstart-pot]
+file_filter = doc/locales/<lang>/LC_MESSAGES/quickstart.po
+minimum_perc = 0
+source_file = _build/locale/quickstart.pot
+source_lang = en
+type = PO
+
+[edgedb-docs.sphinx-pot]
+file_filter = doc/locales/<lang>/LC_MESSAGES/sphinx.po
+minimum_perc = 0
+source_file = _build/locale/sphinx.pot
+source_lang = en
+type = PO

--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ documentation.  The latest published version of this documentation is
 available at [edgedb.com/docs](https://edgedb.com/docs).
 
 
+Translations
+============
+
+The translation project is hosted at Transifex, where you can start to
+contribute translations (please be aware that, EdgeDB is still in an early
+technical preview stage, documentation may still change significantly):
+
+https://www.transifex.com/decentfox-studio/edgedb-docs/
+
+Currently ongoing translations are:
+[Chinese](https://edgedb.readthedocs.io/zh/latest/).
+If you want to contribute to a new language, please file a new issue.
+
+
 License
 =======
 

--- a/doc/locales/zh/LC_MESSAGES/index.po
+++ b/doc/locales/zh/LC_MESSAGES/index.po
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016, magicstack
+# This file is distributed under the same license as the EdgeDB package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: EdgeDB 0.5.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-05-17 15:36+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: fantix <fantix.king@gmail.com>, 2018\n"
+"Language-Team: Chinese (https://www.transifex.com/decentfox-studio/teams/86517/zh/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: ../../doc/index.rst:6
+msgid "EdgeDB documentation"
+msgstr "EdgeDB 文档"
+
+#: ../../doc/index.rst:8
+msgid "Welcome to the EdgeDB |version| documentation."
+msgstr "欢迎来到 EdgeDB |version| 的文档。"

--- a/doc/locales/zh/LC_MESSAGES/intro.po
+++ b/doc/locales/zh/LC_MESSAGES/intro.po
@@ -1,0 +1,77 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016, magicstack
+# This file is distributed under the same license as the EdgeDB package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: EdgeDB 0.5.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-05-17 15:36+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: fantix <fantix.king@gmail.com>, 2018\n"
+"Language-Team: Chinese (https://www.transifex.com/decentfox-studio/teams/86517/zh/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: ../../doc/intro.rst:2
+msgid "Introduction"
+msgstr "介绍"
+
+#: ../../doc/intro.rst:4
+msgid ""
+"EdgeDB is an object-relational database that stores and describes the data "
+"as strongly typed objects and relationships between them."
+msgstr ""
+"EdgeDB 是一种 `对象关系数据库 <https://en.wikipedia.org/wiki/Object-"
+"relational_database>`_，它将数据以强类型的对象及其关系的形式进行描述和存储。"
+
+#: ../../doc/intro.rst:9
+msgid "EdgeDB features:"
+msgstr "EdgeDB 的功能包括："
+
+#: ../../doc/intro.rst:11
+msgid "strict, strongly typed schema;"
+msgstr "严格、强类型的 `数据模式 <https://en.wikipedia.org/wiki/Database_schema>`_；"
+
+#: ../../doc/intro.rst:12
+msgid "powerful and clean query language;"
+msgstr "强大且整洁的查询语言；"
+
+#: ../../doc/intro.rst:13
+msgid "ability to easily work with complex hierarchical data;"
+msgstr "轻松处理复杂的层次结构数据；"
+
+#: ../../doc/intro.rst:14
+msgid "built-in support for schema migrations."
+msgstr "内置的 `数据模式变更 <https://en.wikipedia.org/wiki/Schema_migration>`_ 支持。"
+
+#: ../../doc/intro.rst:16
+msgid ""
+"EdgeDB is not a graph database: the data is stored and queried using "
+"relational database techniques.  Unlike most graph databases, EdgeDB "
+"maintains a strict schema."
+msgstr ""
+"EdgeDB 不是 `图数据库 <https://en.wikipedia.org/wiki/Graph_database>`_，因为 EdgeDB "
+"底层仍然在使用关系数据库的技术来存储和查询数据。不同于大多数的图数据库，EdgeDB 会维护一份严格的模式定义来约束数据。"
+
+#: ../../doc/intro.rst:20
+msgid ""
+"EdgeDB is not a document database, but inserting and querying hierarchical "
+"document-like data is trivial."
+msgstr ""
+"EdgeDB 不是 `面向文档的数据库 <https://en.wikipedia.org/wiki/Document-"
+"oriented_database>`_，但使用 EdgeDB 来创建和查询层次化的文档数据是非常容易的。"
+
+#: ../../doc/intro.rst:23
+msgid ""
+"EdgeDB is not a traditional object database, despite the classification, it "
+"is not an implementation of OOP persistence."
+msgstr ""
+"EdgeDB 不是传统的 `对象数据库 "
+"<https://en.wikipedia.org/wiki/Object_database>`_，抛开概念不说，EdgeDB "
+"没有采用面向对象的持久化方式来实现。"

--- a/doc/locales/zh/LC_MESSAGES/quickstart.po
+++ b/doc/locales/zh/LC_MESSAGES/quickstart.po
@@ -1,0 +1,163 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016, magicstack
+# This file is distributed under the same license as the EdgeDB package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: EdgeDB 0.5.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-05-17 15:36+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: fantix <fantix.king@gmail.com>, 2018\n"
+"Language-Team: Chinese (https://www.transifex.com/decentfox-studio/teams/86517/zh/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: ../../doc/quickstart.rst:3
+msgid "Quickstart"
+msgstr "快速上手"
+
+#: ../../doc/quickstart.rst:6
+msgid "Getting EdgeDB"
+msgstr "获取 EdgeDB"
+
+#: ../../doc/quickstart.rst:8
+msgid ""
+"While EdgeDB is in the technology preview phase, the easiest way to get it "
+"is to download a docker image:"
+msgstr "目前 EdgeDB 处于早期技术预览阶段，最简便的获取方式是下载一个 Docker 镜像："
+
+#: ../../doc/quickstart.rst:17
+msgid "Starting the Server"
+msgstr "启动服务器"
+
+#: ../../doc/quickstart.rst:19
+msgid "To begin, start the EdgeDB server and open an interactive shell to it."
+msgstr "首先，我们要启动一个 EdgeDB 服务器，并且打开一个 EdgeDB 的交互式命令行终端。"
+
+#: ../../doc/quickstart.rst:21
+msgid "If you are using a Docker image, run:"
+msgstr "如果您使用的是 Docker 镜像，则仅需执行该命令即可："
+
+#: ../../doc/quickstart.rst:28
+msgid ""
+"Once the EdgeDB server is up, an interactive shell session will open, "
+"connected to the default database:"
+msgstr "服务器启动完成之后，会自动打开一个 EdgeDB 的交互式命令行终端，并连接到默认数据库："
+
+#: ../../doc/quickstart.rst:37
+msgid "Defining the Schema"
+msgstr "定义数据模式"
+
+#: ../../doc/quickstart.rst:39
+msgid ""
+"For the purpose of this tutorial let's imagine we are building a platform "
+"for collaborative development."
+msgstr "在这篇上手指南中，让我们假设要做一个类似于 GitHub 的协作式开发平台。"
+
+#: ../../doc/quickstart.rst:42
+msgid ""
+"To manipulate and query data in EdgeDB we must first define a schema. We "
+"will be working with three object types: ``User``, ``PullRequest``, and "
+"``Comment``.  Let's define the initial schema with a migration:"
+msgstr ""
+"首先，我们需要定义数据模式，这是之后数据操作和查询的前提。仿照 GitHub，该平台会有三种类型的对象：``User``、``PullRequest``"
+" 和 ``Comment``。下面让我们创建一个模式变更，作为这些初始数据模式的定义："
+
+#: ../../doc/quickstart.rst:72
+msgid ""
+"With the above snippet we defined and applied a migration to a schema "
+"described using the :ref:`declarative schema language <ref_eschema>`. We "
+"created the three main object types, each with a number of properties and "
+"links to other objects."
+msgstr ""
+"通过上述命令，我们用 :ref:`模式定义语言 <ref_eschema>`  "
+"创建了一个模式变更，执行后将数据库模式从零更新至我们定义的数据模式，过程中创建了三个对象类型，每个类型还包括一些属性（``property``），以及指向其他对象的链接（``link``）。"
+
+#: ../../doc/quickstart.rst:77
+msgid ""
+"Notice how the ``PullRequest`` and the ``Comment`` types have common "
+"properties: ``body`` and ``created_on`` as well as the ``author`` link.  "
+"Let's remove this duplication by declaring an abstract parent type "
+"``AuthoredText`` and :ref:`extending <ref_datamodel_inheritance>` "
+"``Comment`` and ``PullRequest`` from it:"
+msgstr ""
+"请注意 ``PullRequest`` 类型与 ``Comment`` 类型有一部分属性是相同的：``body`` 与 "
+"``created_on``，以及链接 ``author``。为了避免代码重复，我们应创建一个抽象类型 ``AuthoredText`` "
+"作为父类型，并使 ``Comment`` 与 ``PullRequest`` :ref:`继承 <ref_datamodel_inheritance>`"
+" ``AuthoredText``："
+
+#: ../../doc/quickstart.rst:116
+msgid "Inserting Data"
+msgstr "新增数据"
+
+#: ../../doc/quickstart.rst:118
+msgid "Now that we've defined the schema, let's create some users:"
+msgstr "定义好了数据模式，现在我们可以创建一些用户了："
+
+#: ../../doc/quickstart.rst:147
+msgid "Then, a ``PullRequest`` object:"
+msgstr "然后是一个 ``PullRequest`` 对象："
+
+#: ../../doc/quickstart.rst:165
+msgid ""
+"\"PR #1\" has been commented on, let's update it with a new ``Comment`` "
+"object:"
+msgstr "“PR #1”上有新评论了，我们给它添加一个 ``Comment`` 对象："
+
+#: ../../doc/quickstart.rst:184
+msgid "Let's create another PR, together with the corresponding comments:"
+msgstr "接下来再创建一个 PR，这次我们把它的评论一并创建出来："
+
+#: ../../doc/quickstart.rst:226
+msgid "Querying Data"
+msgstr "查询数据"
+
+#: ../../doc/quickstart.rst:228
+msgid "Now that we inserted some data, let’s run some queries!"
+msgstr "新增了数据之后，现在我们可以跑几个查询试试了！"
+
+#: ../../doc/quickstart.rst:230
+msgid ""
+"Get all \"Open\" pull requests, their authors, and who they are assigned to,"
+" in reverse chronological order:"
+msgstr "以从新到旧的顺序，获取所有“打开”状态的 PR，以及他们的发起人和负责人："
+
+#: ../../doc/quickstart.rst:251 ../../doc/quickstart.rst:289
+#: ../../doc/quickstart.rst:348
+msgid "Result:"
+msgstr "结果如下："
+
+#: ../../doc/quickstart.rst:270
+msgid ""
+"Now, let's see which PRs a particular user has authored or commented on, and"
+" let's also return the count of comments for each returned PR:"
+msgstr "然后，让我们尝试找到一个用户发起的或评论过的所有 PR，以及每个 PR 上的评论数量："
+
+#: ../../doc/quickstart.rst:308
+msgid "Deleting Data"
+msgstr "删除数据"
+
+#: ../../doc/quickstart.rst:310
+msgid ""
+"Suppose we need to remove all content authored by Carol.  First, let's see "
+"which entries are by Carol:"
+msgstr "比方说，现在我们需要删除卡罗尔同学产生的所有数据。第一步，我们先看一下卡罗尔同学一共创建过多少内容："
+
+#: ../../doc/quickstart.rst:323
+msgid ""
+"In the above query we used the fact that all authored objects can be "
+"selected by referring to the ``AuthoredText`` type.  Since we have two "
+"objects authored by Carol--a pull request, and a comment--the result is:"
+msgstr ""
+"在上面的查询中，我们直接使用了父类型 ``AuthoredText`` 进行查询，而实际上所有 ``AuthoredText`` "
+"的子类型的对象都能被查询到。因为卡罗尔同学只创建了一个 PR 和一条评论，所以我们得到的结果是："
+
+#: ../../doc/quickstart.rst:339
+msgid "Let's delete them now:"
+msgstr "现在可以删除他们了："

--- a/doc/locales/zh/LC_MESSAGES/sphinx.po
+++ b/doc/locales/zh/LC_MESSAGES/sphinx.po
@@ -1,0 +1,43 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016, magicstack
+# This file is distributed under the same license as the EdgeDB package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: EdgeDB 0.5.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-05-17 15:36+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: fantix <fantix.king@gmail.com>, 2018\n"
+"Language-Team: Chinese (https://www.transifex.com/decentfox-studio/teams/86517/zh/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: ../../doc/_templates/srclinks.html:2
+msgid "This Page"
+msgstr "当前页面"
+
+#: ../../doc/_templates/srclinks.html:6
+msgid "Source RST"
+msgstr "RST 源文件"
+
+#: ../../doc/_templates/srclinks.html:10
+msgid "Source"
+msgstr "源码"
+
+#: ../../doc/_templates/srclinks.html:15
+msgid "Edit"
+msgstr "编辑"
+
+#: ../../doc/_templates/srclinks.html:20
+msgid "History"
+msgstr "历史"
+
+#: ../../doc/_templates/srclinks.html:25
+msgid "Annotate"
+msgstr "注解"

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: edgedb
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.6
+  - pip:
+    - lxml
+    - git+https://github.com/edgedb/edgedb.git

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+python:
+   version: 3
+   pip_install: true
+conda:
+    file: environment.yml

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,3 +2,4 @@
 requests-xml
 pytest
 flake8
+transifex-client


### PR DESCRIPTION
I made a simple start on translating this documentation to other languages. I'm aware that it might be just way too early to start translating anything, but the support is quite simple and it won't break easily. Here's what has been done:

* A [Transifex project](https://www.transifex.com/decentfox-studio/edgedb-docs/) is created (under my organization for now, feel free to let me know if you want it transferred elsewhere)
* Config file for [Transifex client](https://github.com/transifex/transifex-client) is added for convenient `tx push` and `tx pull`
* A [readthedocs project](https://readthedocs.org/projects/edgedb/) is created to build and host translated documentation (also under my account, let me know if you need it)
* Redirected https://edgedb.readthedocs.io/ to https://edgedb.com/docs/
* Translated the tutorial into [Chinese](https://edgedb.readthedocs.io/zh/latest/intro.html)
